### PR TITLE
env: Add svelte-preprocess

### DIFF
--- a/build/webpack.common.js
+++ b/build/webpack.common.js
@@ -3,6 +3,7 @@ const { CleanWebpackPlugin } = require('clean-webpack-plugin')
 const miniCssExtractPlugin = require('mini-css-extract-plugin')
 const CopyWebpackPlugin = require('copy-webpack-plugin')
 const FriendlyErrors = require('friendly-errors-webpack-plugin')
+const SveltePreprocess = require('svelte-preprocess')
 
 module.exports = {
   entry: {
@@ -23,7 +24,12 @@ module.exports = {
       },
       {
         test: /\.svelte$/,
-        use: 'svelte-loader',
+        use: {
+          loader: 'svelte-loader',
+          options: {
+            preprocess: SveltePreprocess.typescript(),
+          }
+        },
       },
       {
         test: /\.(css|less)$/,

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "markdown-it-table-of-contents": "^0.5.2",
     "markdown-it-task-lists": "^2.1.1",
     "md-reader-theme-juejin": "^1.0.1",
-    "svelte": "^3.44.0"
+    "svelte": "^3.44.0",
+    "svelte-preprocess": "^4.9.8"
   }
 }


### PR DESCRIPTION
To use the ts preprocessor(such as `let a:string`) in `<script lang="ts">`
I added svelte-preprocess module.