### PR TITLE
support digraph diagrams

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@smui/select": "^4.2.0",
     "@smui/switch": "^4.2.0",
     "@traptitech/markdown-it-katex": "^3.6.0",
+    "@viz-js/viz": "^3.27.0",
     "highlight.js": "^11.6.0",
     "lodash.debounce": "^4.0.8",
     "lodash.throttle": "^4.1.1",

--- a/src/core/graphviz.ts
+++ b/src/core/graphviz.ts
@@ -1,0 +1,55 @@
+const GRAPHVIZ_INFO_TOKENS = new Set(['digraph', 'dot', 'graphviz'])
+const GRAPHVIZ_SOURCE_PREFIX =
+  /^(?:strict\s+)?(?:(?:di)?graph\b(?:\s+["\w.-]+)?\s*\{|(?:di)?graph\s*\{)/i
+
+export const GRAPHVIZ_CLASS = 'md-reader__graphviz'
+export const GRAPHVIZ_CONTENT_CLASS = `${GRAPHVIZ_CLASS}-content`
+export const GRAPHVIZ_ERROR_CLASS = `${GRAPHVIZ_CLASS}-error`
+export const GRAPHVIZ_SOURCE_ATTR = 'data-graphviz-source'
+export const GRAPHVIZ_STATUS_ATTR = 'data-graphviz-status'
+
+export function isGraphvizCodeBlock(
+  info: string = '',
+  code: string = '',
+): boolean {
+  const token = info.trim().toLowerCase()
+  if (GRAPHVIZ_INFO_TOKENS.has(token)) {
+    return true
+  }
+  if (token === 'mermaid') {
+    return GRAPHVIZ_SOURCE_PREFIX.test(code.trimStart())
+  }
+  return false
+}
+
+export function encodeGraphvizSource(code: string): string {
+  const utf8 = encodeURIComponent(code).replace(
+    /%([0-9A-F]{2})/g,
+    (_, hex: string) => String.fromCharCode(parseInt(hex, 16)),
+  )
+  return btoa(utf8)
+}
+
+export function decodeGraphvizSource(value: string): string {
+  const utf8 = atob(value)
+  const encoded = Array.from(
+    utf8,
+    char => `%${char.charCodeAt(0).toString(16).padStart(2, '0')}`,
+  ).join('')
+  return decodeURIComponent(encoded)
+}
+
+export function renderGraphvizPlaceholder(code: string): string {
+  const source = encodeGraphvizSource(code)
+  return `<pre class="${GRAPHVIZ_CLASS}" ${GRAPHVIZ_SOURCE_ATTR}="${source}" ${GRAPHVIZ_STATUS_ATTR}="pending"><code class="${GRAPHVIZ_CONTENT_CLASS}">${escapeHtml(
+    code,
+  )}</code></pre>`
+}
+
+function escapeHtml(content: string): string {
+  return String(content)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}

--- a/src/core/markdown.ts
+++ b/src/core/markdown.ts
@@ -13,6 +13,7 @@ import mToc from 'markdown-it-table-of-contents'
 import mKatex from '@traptitech/markdown-it-katex'
 import mMermaid from '@md-reader/markdown-it-mermaid'
 import mAlert from '@/plugins/alert'
+import mGraphvizBlock from '@/plugins/graphviz-block'
 import mMultimdTable from 'markdown-it-multimd-table'
 import MD_PLUGINS from '@/config/md-plugins'
 import successIcon from '@/images/icon_success.svg'
@@ -96,6 +97,12 @@ function initRender({ config = {}, plugins = [...MD_PLUGINS] }: MdOptions) {
     }
     plugin && md.use(plugin[0], ...plugin.slice(1))
   })
+
+  if (plugins.includes('Mermaid')) {
+    // Install after diagram plugins so Graphviz can override Mermaid fences when
+    // the block content is actually DOT syntax.
+    md.use(mGraphvizBlock)
+  }
 
   return md
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -97,6 +97,10 @@ function main(data: Data) {
         plugins: configData.mdPlugins,
         ...options,
       })
+      globalEvent.emit(
+        'contentRendered',
+        target instanceof Ele ? target.ele : target,
+      )
     }
   const contentRender = mdRenderer(mdContent)
   contentRender(mdRaw)

--- a/src/plugins/graphviz-block.ts
+++ b/src/plugins/graphviz-block.ts
@@ -1,0 +1,22 @@
+import type MarkdownIt from 'markdown-it'
+import { isGraphvizCodeBlock, renderGraphvizPlaceholder } from '@/core/graphviz'
+
+export default function GraphvizBlockPlugin(md: MarkdownIt) {
+  const fallbackFence = md.renderer.rules.fence?.bind(md.renderer.rules)
+
+  md.renderer.rules.fence = (tokens, idx, options, env, self) => {
+    const token = tokens[idx]
+    const info = token.info.trim()
+    const code = token.content.trim()
+
+    if (isGraphvizCodeBlock(info, code)) {
+      return renderGraphvizPlaceholder(code)
+    }
+
+    if (fallbackFence) {
+      return fallbackFence(tokens, idx, options, env, self)
+    }
+
+    return self.renderToken(tokens, idx, options)
+  }
+}

--- a/src/plugins/graphviz-renderer.ts
+++ b/src/plugins/graphviz-renderer.ts
@@ -1,0 +1,75 @@
+import { instance } from '@viz-js/viz'
+import {
+  decodeGraphvizSource,
+  GRAPHVIZ_CLASS,
+  GRAPHVIZ_CONTENT_CLASS,
+  GRAPHVIZ_ERROR_CLASS,
+  GRAPHVIZ_SOURCE_ATTR,
+  GRAPHVIZ_STATUS_ATTR,
+} from '@/core/graphviz'
+
+let vizPromise: ReturnType<typeof instance> | null = null
+
+function getViz() {
+  if (!vizPromise) {
+    vizPromise = instance()
+  }
+  return vizPromise
+}
+
+function createErrorElement(message: string) {
+  const error = document.createElement('div')
+  error.className = GRAPHVIZ_ERROR_CLASS
+  error.textContent = message
+  return error
+}
+
+async function renderGraphvizElement(element: HTMLElement) {
+  const status = element.getAttribute(GRAPHVIZ_STATUS_ATTR)
+  if (status === 'rendering' || status === 'ready') {
+    return
+  }
+
+  const source = element.getAttribute(GRAPHVIZ_SOURCE_ATTR)
+  if (!source) {
+    return
+  }
+
+  const code = decodeGraphvizSource(source)
+  const codeElement = element.querySelector(`.${GRAPHVIZ_CONTENT_CLASS}`)
+  const previousError = element.querySelector(`.${GRAPHVIZ_ERROR_CLASS}`)
+  previousError?.remove()
+
+  element.setAttribute(GRAPHVIZ_STATUS_ATTR, 'rendering')
+
+  try {
+    const viz = await getViz()
+    const svg = viz.renderSVGElement(code)
+    svg.classList.add(`${GRAPHVIZ_CLASS}-svg`)
+    codeElement?.replaceWith(svg)
+    element.setAttribute(GRAPHVIZ_STATUS_ATTR, 'ready')
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    if (!codeElement) {
+      const fallbackCode = document.createElement('code')
+      fallbackCode.className = GRAPHVIZ_CONTENT_CLASS
+      fallbackCode.textContent = code
+      element.appendChild(fallbackCode)
+    }
+    element.appendChild(createErrorElement(message))
+    element.setAttribute(GRAPHVIZ_STATUS_ATTR, 'error')
+  }
+}
+
+export async function renderGraphviz(container: ParentNode = document) {
+  const elements = Array.from(
+    container.querySelectorAll<HTMLElement>(`.${GRAPHVIZ_CLASS}`),
+  )
+  await Promise.all(elements.map(element => renderGraphvizElement(element)))
+}
+
+export default function GraphvizRendererPlugin({ event }) {
+  event.on('contentRendered', (container: HTMLElement) => {
+    void renderGraphviz(container)
+  })
+}

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -1,6 +1,7 @@
 import imageViewerPlugin from './img-viewer'
 import blockCopyPlugin from './block-copy'
+import graphvizRendererPlugin from './graphviz-renderer'
 import { usePlugin } from '@/core/plugin'
 export { initPlugins } from '@/core/plugin'
 
-usePlugin([blockCopyPlugin, imageViewerPlugin])
+usePlugin([blockCopyPlugin, imageViewerPlugin, graphvizRendererPlugin])

--- a/src/style/index.less
+++ b/src/style/index.less
@@ -143,6 +143,21 @@ body.md-reader {
             }
           }
         }
+        pre.md-reader__graphviz {
+          overflow: auto;
+          padding: 16px;
+          svg {
+            display: block;
+            max-width: 100%;
+            height: auto;
+            margin: 0 auto;
+          }
+          .md-reader__graphviz-error {
+            margin-top: 12px;
+            color: #d14343;
+            white-space: pre-wrap;
+          }
+        }
       }
     }
 

--- a/tests/graphviz.test.mjs
+++ b/tests/graphviz.test.mjs
@@ -1,0 +1,95 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import MarkdownIt from 'markdown-it'
+import MermaidPlugin from '@md-reader/markdown-it-mermaid'
+
+const loadGraphviz = () => import('../src/core/graphviz.ts')
+
+test('treats digraph blocks as graphviz diagrams', async () => {
+  const { isGraphvizCodeBlock } = await loadGraphviz()
+
+  assert.equal(isGraphvizCodeBlock('digraph', 'digraph G { a -> b }'), true)
+  assert.equal(isGraphvizCodeBlock('dot', 'digraph G { a -> b }'), true)
+  assert.equal(isGraphvizCodeBlock('graphviz', 'graph G { a -- b }'), true)
+})
+
+test('routes digraph content inside mermaid fences to graphviz', async () => {
+  const { isGraphvizCodeBlock } = await loadGraphviz()
+
+  assert.equal(isGraphvizCodeBlock('mermaid', 'digraph G { a -> b }'), true)
+})
+
+test('keeps regular mermaid flowcharts on the mermaid renderer', async () => {
+  const { isGraphvizCodeBlock } = await loadGraphviz()
+
+  assert.equal(
+    isGraphvizCodeBlock('mermaid', 'graph TD\n  A[Start] --> B[Done]'),
+    false,
+  )
+})
+
+test('encodes graphviz placeholders safely', async () => {
+  const { decodeGraphvizSource, renderGraphvizPlaceholder } =
+    await loadGraphviz()
+  const code = 'digraph G {\n  a -> b [label="a < b"];\n}'
+
+  const html = renderGraphvizPlaceholder(code)
+  const sourceMatch = html.match(/data-graphviz-source="([^"]+)"/)
+
+  assert.ok(sourceMatch, 'expected graphviz source data attribute')
+  assert.equal(decodeGraphvizSource(sourceMatch[1]), code)
+  assert.match(html, /md-reader__graphviz/)
+})
+
+test('markdown-it integration can route graphviz fences without touching mermaid flowcharts', async () => {
+  const { isGraphvizCodeBlock, renderGraphvizPlaceholder } =
+    await loadGraphviz()
+  const md = new MarkdownIt()
+  const fallbackFence = md.renderer.rules.fence?.bind(md.renderer.rules)
+
+  md.renderer.rules.fence = (tokens, idx, options, env, self) => {
+    const token = tokens[idx]
+    const info = token.info.trim()
+    const code = token.content.trim()
+
+    if (isGraphvizCodeBlock(info, code)) {
+      return renderGraphvizPlaceholder(code)
+    }
+
+    return fallbackFence
+      ? fallbackFence(tokens, idx, options, env, self)
+      : self.renderToken(tokens, idx, options)
+  }
+
+  const dotHtml = md.render('```digraph\ndigraph G { a -> b }\n```')
+  const mermaidHtml = md.render('```mermaid\ngraph TD\n  A --> B\n```')
+
+  assert.match(dotHtml, /md-reader__graphviz/)
+  assert.doesNotMatch(mermaidHtml, /md-reader__graphviz/)
+})
+
+test('graphviz override still works after mermaid plugin is installed first', async () => {
+  const { isGraphvizCodeBlock, renderGraphvizPlaceholder } =
+    await loadGraphviz()
+  const md = new MarkdownIt()
+  md.use(MermaidPlugin)
+
+  const fallbackFence = md.renderer.rules.fence?.bind(md.renderer.rules)
+  md.renderer.rules.fence = (tokens, idx, options, env, self) => {
+    const token = tokens[idx]
+    const info = token.info.trim()
+    const code = token.content.trim()
+
+    if (isGraphvizCodeBlock(info, code)) {
+      return renderGraphvizPlaceholder(code)
+    }
+
+    return fallbackFence
+      ? fallbackFence(tokens, idx, options, env, self)
+      : self.renderToken(tokens, idx, options)
+  }
+
+  const html = md.render('```mermaid\ndigraph G { a -> b }\n```')
+
+  assert.match(html, /md-reader__graphviz/)
+})


### PR DESCRIPTION
## Summary

Add support for Graphviz/DOT `digraph` diagrams in Markdown Reader.

## What changed

- detect `digraph`, `dot`, and `graphviz` fenced code blocks
- route DOT content inside `mermaid` fences to Graphviz when the content is actually DOT syntax
- render Graphviz blocks to SVG in the content page using `@viz-js/viz`
- keep the behavior behind the existing Mermaid plugin toggle
- add regression tests for Graphviz block detection and Mermaid fallback behavior

## Why

The extension already supports Mermaid diagrams, but it could not render Graphviz/DOT `digraph` blocks. This change adds a dedicated Graphviz path without breaking normal Mermaid flowcharts.

## Validation

- `node --experimental-strip-types --test .\\tests\\graphviz.test.mjs`
- `npx tsc --noEmit`
- `npm run build:extension`